### PR TITLE
fix: Fix using `help.markdown` field.

### DIFF
--- a/sarif/reporting_descriptor.go
+++ b/sarif/reporting_descriptor.go
@@ -71,7 +71,10 @@ func (rule *ReportingDescriptor) WithHelp(helpText string) *ReportingDescriptor 
 
 // WithMarkdownHelp specifies a help text  for a rule and returns the updated rule
 func (rule *ReportingDescriptor) WithMarkdownHelp(markdownText string) *ReportingDescriptor {
-	rule.Help = NewMarkdownMultiformatMessageString(markdownText)
+	if rule.Help == nil {
+		rule.Help = NewMultiformatMessageString("")
+	}
+	rule.Help.WithMarkdown(markdownText)
 	return rule
 }
 

--- a/sarif/tool.go
+++ b/sarif/tool.go
@@ -4,4 +4,3 @@ type Tool struct {
 	PropertyBag
 	Driver *ToolComponent `json:"driver"`
 }
-


### PR DESCRIPTION
When `rule.Help` isn't exist, this one will be created with an empty text field.
Then `markdown` will added to an existing `help`.

aslo I've run `go fmt`.

fixes #29 