### PR TITLE
Add json:omitempty to Suppression fields

### DIFF
--- a/sarif/suppression.go
+++ b/sarif/suppression.go
@@ -3,11 +3,11 @@ package sarif
 // Suppression ...
 type Suppression struct {
 	PropertyBag
-	Kind          string    `json:"kind"`
-	Status        *string   `json:"status"`
-	Location      *Location `json:"location"`
-	Guid          *string   `json:"guid"`
-	Justification *string   `json:"justification"`
+	Kind          string    `json:"kind,omitempty"`
+	Status        *string   `json:"status,omitempty"`
+	Location      *Location `json:"location,omitempty"`
+	Guid          *string   `json:"guid,omitempty"`
+	Justification *string   `json:"justification,omitempty"`
 }
 
 // NewSuppression ...


### PR DESCRIPTION
Thanks for this library!

I was looking at suppressions, and found that there are some optional properties.
These currently get set to `null` which conflicts with the format, these should be
strings or location objects if set, and omitted otherwise.