### PR TITLE
fix: Update the version URLs

### DIFF
--- a/v2/sarif/sarif.go
+++ b/v2/sarif/sarif.go
@@ -12,10 +12,14 @@ import (
 type Version string
 
 // Version210 represents Version210 of Sarif
-const Version210 Version = "2.1.0"
+const (
+	Version210     Version = "2.1.0"
+	Version210RTM5 Version = "2.1.0-rtm.5"
+)
 
 var versions = map[Version]string{
-	Version210: "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+	Version210:     "https://json.schemastore.org/sarif-2.1.0.json",
+	Version210RTM5: "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
 }
 
 // Report is the encapsulating type representing a Sarif Report
@@ -28,17 +32,17 @@ type Report struct {
 }
 
 // New Creates a new Report or returns an error
-func New(version Version, includeSchema... bool) (*Report, error) {
-  schema := ""
+func New(version Version, includeSchema ...bool) (*Report, error) {
+	schema := ""
 
-  if len(includeSchema) == 0 || includeSchema[0] {
-    var err error
+	if len(includeSchema) == 0 || includeSchema[0] {
+		var err error
 
-	  schema, err = getVersionSchema(version)
-	  if err != nil {
-		  return nil, err
-	  }
-  }
+		schema, err = getVersionSchema(version)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &Report{
 		Version: string(version),
 		Schema:  schema,


### PR DESCRIPTION
URL for v2.1.0 goes to the rtm5 URL rather than the final specification.

Updated the schemas to add the option to use 210RTM5 or 210Final

Signed-off-by: Owen Rumney <owen@owenrumney.co.uk>

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #58 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
