### PR TITLE
fix: add omitempty annotation to messageStrings

### DIFF
--- a/v2/sarif/reporting_descriptor.go
+++ b/v2/sarif/reporting_descriptor.go
@@ -13,7 +13,7 @@ type ReportingDescriptor struct {
 	DeprecatedNames      []string                  `json:"deprecatedNames,omitempty"`
 	HelpURI              *string                   `json:"helpUri,omitempty"`
 	Help                 *MultiformatMessageString `json:"help,omitempty"`
-	MessageStrings       *MessageStrings           `json:"messageStrings"`
+	MessageStrings       *MessageStrings           `json:"messageStrings,omitempty"`
 	Properties           Properties                `json:"properties,omitempty"`
 }
 


### PR DESCRIPTION
change in #63 add messageStrings to the reportingDescriptor but didn't
mark as being `omitempty`. This resolves #67 
