### PR TITLE
remove ioutil, use testing.TempDir

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -96,7 +95,7 @@ func main() {
 // load the example results file
 func loadTfsecResults() (TfsecResults, error) {
 
-	jsonResult, err := ioutil.ReadFile("../example/results.json")
+	jsonResult, err := os.ReadFile("../example/results.json")
 	if err != nil {
 		panic(err)
 	}

--- a/sarif/sarif.go
+++ b/sarif/sarif.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -45,7 +44,7 @@ func Open(filename string) (*Report, error) {
 		return nil, fmt.Errorf("the provided file path doesn't have a file")
 	}
 
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("the provided filepath could not be opened. %w", err)
 	}

--- a/test/report_test.go
+++ b/test/report_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -93,11 +92,11 @@ func Test_load_sarif_report_from_file(t *testing.T) {
   ]
 }`
 
-	file, err := ioutil.TempFile(os.TempDir(), "sarifReport")
+	file, err := os.CreateTemp(t.TempDir(), "sarifReport")
 	assert.NoError(t, err)
 	defer file.Close()
 
-	ioutil.WriteFile(file.Name(), []byte(content), 755)
+	os.WriteFile(file.Name(), []byte(content), 755)
 
 	given.a_report_is_loaded_from_a_file(file.Name())
 	then.the_report_has_expected_driver_name_and_information_uri("ESLint", "https://eslint.org")

--- a/v2/sarif/sarif.go
+++ b/v2/sarif/sarif.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -58,7 +57,7 @@ func Open(filename string) (*Report, error) {
 		return nil, fmt.Errorf("the provided file path doesn't have a file")
 	}
 
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("the provided filepath could not be opened. %w", err)
 	}

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -93,11 +92,11 @@ func Test_load_sarif_report_from_file(t *testing.T) {
   ]
 }`
 
-	file, err := ioutil.TempFile(os.TempDir(), "sarifReport")
+	file, err := os.TempFile(t.TempDir(), "sarifReport")
 	assert.NoError(t, err)
 	defer file.Close()
 
-	ioutil.WriteFile(file.Name(), []byte(content), 755)
+	os.WriteFile(file.Name(), []byte(content), 755)
 
 	given.a_report_is_loaded_from_a_file(file.Name())
 	then.the_report_has_expected_driver_name_and_information_uri("ESLint", "https://eslint.org")


### PR DESCRIPTION
## 📑 Description

- replace [ioutil.TempFile](https://pkg.go.dev/io/ioutil#TempFile) to [os.CreateTemp](https://pkg.go.dev/os#CreateTemp), replace [ioutil.ReadFile](https://pkg.go.dev/io/ioutil#ReadFile) to [os.ReadFile](https://pkg.go.dev/os#ReadFile)
  - Its deprecated.  
- replace [os.TempDir](https://pkg.go.dev/os#TempDir) to [testing.TempDir](https://pkg.go.dev/testing#T.TempDir)
  - it is automatically removed by Cleanup when the test and all its subtests complete.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
  - No changes required. 
- [x] I have updated the documentation as required
  - No changes required. 
- [x] All the tests have passed

## ℹ Additional Information

