### PR TITLE
Support Tool.Extensions property & Fix and include v2 tests in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: test
 test: vet
-	go test -v  ./...
+	go test -v  ./... && cd v2 && go test -v  ./...
 
 .PHONY: vet
 vet:

--- a/v2/sarif/sarif.go
+++ b/v2/sarif/sarif.go
@@ -18,7 +18,7 @@ const (
 )
 
 var versions = map[Version]string{
-	Version210: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+	Version210: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
 	// keeping this for backwards support but marked as deprecated
 	Version210RTM5: "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
 }

--- a/v2/sarif/tool.go
+++ b/v2/sarif/tool.go
@@ -2,9 +2,9 @@ package sarif
 
 // Tool ...
 type Tool struct {
-	Driver *ToolComponent `json:"driver"`
+	Driver     *ToolComponent   `json:"driver"`
+	Extensions []*ToolComponent `json:"extensions,omitempty"`
 	PropertyBag
-
 }
 
 // NewTool creates a new Tool and returns a pointer to it
@@ -19,4 +19,15 @@ func NewSimpleTool(driverName string) *Tool {
 	return &Tool{
 		Driver: NewDriver(driverName),
 	}
+}
+
+// WithExtensions sets the Extensions
+func (tool *Tool) WithExtensions(extensions []*ToolComponent) *Tool {
+	tool.Extensions = extensions
+	return tool
+}
+
+// AddExtension ...
+func (tool *Tool) AddExtension(extension *ToolComponent) {
+	tool.Extensions = append(tool.Extensions, extension)
 }

--- a/v2/test/report_stage_test.go
+++ b/v2/test/report_stage_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/owenrumney/go-sarif/sarif"
+	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,13 +33,13 @@ func (r *reportTest) and() *reportTest {
 }
 
 func (r *reportTest) with_a_run_added(tool, informationUri string) *sarif.Run {
-	run := sarif.NewRun(tool, informationUri)
+	run := sarif.NewRunWithInformationURI(tool, informationUri)
 	r.report.AddRun(run)
 	return run
 }
 
 func (r *reportTest) with_a_run_with_empty_result_added(tool, informationUri string) *sarif.Run {
-	run := sarif.NewRun(tool, informationUri)
+	run := sarif.NewRunWithInformationURI(tool, informationUri)
 	r.report.AddRun(run)
 	return run
 }
@@ -87,4 +87,9 @@ func (r *reportTest) a_report_is_loaded_from_a_file(filename string) {
 	}
 	r.report = report
 
+}
+
+func (r *reportTest) the_report_has_expected_extension_name_and_semantic_version(extensionName string, semanticVersion string) {
+	assert.Equal(r.t, extensionName, r.report.Runs[0].Tool.Extensions[0].Name)
+	assert.Equal(r.t, semanticVersion, *r.report.Runs[0].Tool.Extensions[0].SemanticVersion)
 }

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -20,7 +20,7 @@ func Test_new_report_with_empty_run(t *testing.T) {
 
 	given.a_new_report().
 		with_a_run_with_empty_result_added("tfsec", "https://tfsec.dev")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[]}]}`)
 }
 
 func Test_new_simple_report_with_artifact(t *testing.T) {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -38,7 +38,7 @@ func Test_new_simple_report_with_propertybag(t *testing.T) {
 	run := given.a_new_report().
 		with_a_run_added("tfsec", "https://tfsec.dev")
 	when.some_properties_are_added_to_the_run(run)
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[],"properties":{"integer_property":10,"string_property":"this is a string"}}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[],"properties":{"integer_property":10,"string_property":"this is a string"}}]}`)
 }
 
 func Test_new_simple_report_with_duplicate_artifact(t *testing.T) {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -107,7 +107,7 @@ func Test_load_sarif_report_from_file(t *testing.T) {
 
 	content := `{
   "version": "2.1.0",
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "runs": [
     {
       "tool": {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -12,7 +12,7 @@ func Test_new_simple_report_with_single_run(t *testing.T) {
 
 	given.a_new_report().
 		with_a_run_added("tfsec", "https://tfsec.dev")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[]}]}`)
 }
 
 func Test_new_report_with_empty_run(t *testing.T) {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -57,7 +57,7 @@ func Test_load_sarif_from_string(t *testing.T) {
 
 	content := `{
   "version": "2.1.0",
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "runs": [
     {
       "tool": {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -49,7 +49,7 @@ func Test_new_simple_report_with_duplicate_artifact(t *testing.T) {
 	when.an_artifact_is_added_to_the_run(run, "file://broken.go").
 		and().
 		an_artifact_is_added_to_the_run(run, "file://broken.go")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1},{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1},{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
 }
 
 func Test_load_sarif_from_string(t *testing.T) {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -29,7 +29,7 @@ func Test_new_simple_report_with_artifact(t *testing.T) {
 	run := given.a_new_report().
 		with_a_run_added("tfsec", "https://tfsec.dev")
 	when.an_artifact_is_added_to_the_run(run, "file://broken.go")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
 }
 
 func Test_new_simple_report_with_propertybag(t *testing.T) {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -79,7 +79,7 @@ func Test_load_sarif_from_string_with_extensions(t *testing.T) {
 
 	content := `{
   "version": "2.1.0",
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "runs": [
     {
       "tool": {

--- a/v2/test/report_test.go
+++ b/v2/test/report_test.go
@@ -12,7 +12,7 @@ func Test_new_simple_report_with_single_run(t *testing.T) {
 
 	given.a_new_report().
 		with_a_run_added("tfsec", "https://tfsec.dev")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"tfsec","informationUri":"https://tfsec.dev"}},"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[]}]}`)
 }
 
 func Test_new_report_with_empty_run(t *testing.T) {
@@ -20,7 +20,7 @@ func Test_new_report_with_empty_run(t *testing.T) {
 
 	given.a_new_report().
 		with_a_run_with_empty_result_added("tfsec", "https://tfsec.dev")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"tfsec","informationUri":"https://tfsec.dev"}},"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[]}]}`)
 }
 
 func Test_new_simple_report_with_artifact(t *testing.T) {
@@ -29,7 +29,7 @@ func Test_new_simple_report_with_artifact(t *testing.T) {
 	run := given.a_new_report().
 		with_a_run_added("tfsec", "https://tfsec.dev")
 	when.an_artifact_is_added_to_the_run(run, "file://broken.go")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"tfsec","informationUri":"https://tfsec.dev"}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
 }
 
 func Test_new_simple_report_with_propertybag(t *testing.T) {
@@ -38,7 +38,7 @@ func Test_new_simple_report_with_propertybag(t *testing.T) {
 	run := given.a_new_report().
 		with_a_run_added("tfsec", "https://tfsec.dev")
 	when.some_properties_are_added_to_the_run(run)
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"tfsec","informationUri":"https://tfsec.dev"}},"results":[],"properties":{"integer_property":10,"string_property":"this is a string"}}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"results":[],"properties":{"integer_property":10,"string_property":"this is a string"}}]}`)
 }
 
 func Test_new_simple_report_with_duplicate_artifact(t *testing.T) {
@@ -49,7 +49,7 @@ func Test_new_simple_report_with_duplicate_artifact(t *testing.T) {
 	when.an_artifact_is_added_to_the_run(run, "file://broken.go").
 		and().
 		an_artifact_is_added_to_the_run(run, "file://broken.go")
-	then.report_text_is(`{"version":"2.1.0","$schema":"https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"tfsec","informationUri":"https://tfsec.dev"}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1},{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
+	then.report_text_is(`{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://tfsec.dev","name":"tfsec","rules":[]}},"artifacts":[{"location":{"uri":"file://broken.go"},"length":-1},{"location":{"uri":"file://broken.go"},"length":-1}],"results":[]}]}`)
 }
 
 func Test_load_sarif_from_string(t *testing.T) {
@@ -57,7 +57,7 @@ func Test_load_sarif_from_string(t *testing.T) {
 
 	content := `{
   "version": "2.1.0",
-  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "tool": {
@@ -74,12 +74,40 @@ func Test_load_sarif_from_string(t *testing.T) {
 	then.the_report_has_expected_driver_name_and_information_uri("ESLint", "https://eslint.org")
 }
 
+func Test_load_sarif_from_string_with_extensions(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	content := `{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint",
+          "informationUri": "https://eslint.org"
+        },
+        "extensions": [
+            {
+            "name": "Extension1",
+            "semanticVersion": "1.0.0-rc"
+			}
+		]
+      }
+    }
+  ]
+}`
+
+	given.a_report_is_loaded_from_a_string(content)
+	then.the_report_has_expected_extension_name_and_semantic_version("Extension1", "1.0.0-rc")
+}
+
 func Test_load_sarif_report_from_file(t *testing.T) {
 	given, _, then := newReportTest(t)
 
 	content := `{
   "version": "2.1.0",
-  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "tool": {
@@ -92,7 +120,7 @@ func Test_load_sarif_report_from_file(t *testing.T) {
   ]
 }`
 
-	file, err := os.TempFile(t.TempDir(), "sarifReport")
+	file, err := os.CreateTemp(t.TempDir(), "sarifReport")
 	assert.NoError(t, err)
 	defer file.Close()
 

--- a/v2/test/run_test.go
+++ b/v2/test/run_test.go
@@ -11,7 +11,7 @@ func Test_new_result_on_run(t *testing.T) {
 func Test_properties_on_a_run(t *testing.T) {
 	given, when, then := newRunTest(t)
 
-	expected := `{"tool":{"driver":null},"results":[],"properties":{"boolean_key":false,"string_key":"string_value"}}`
+	expected := `{"tool":{"driver":{"name":"driver1","rules":[]}},"results":[],"properties":{"boolean_key":false,"string_key":"string_value"}}`
 
 	given.properties_added_to_a_run()
 	when.the_run_is_json()


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
<!-- Add a brief description of the pr -->

Support Tool.Extensions property, whose value is an array of toolComponent objects. See https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790782

Example:
```
{                          # A tool object.
  "driver": {              # See §3.18.2.
    "name": "CodeScanner",
    "fullName": "CodeScanner 1.1, Developer Preview (en-US)",
    "semanticVersion": "1.1.2-beta.12",
    "version": "1.1.2b12",
    ...
  },
  "extensions": [          # See §3.18.3.
    {
      "name": "CodeScanner Security Rules",
      "version": "3.1",
      ...
    }
  ]
}
```

Also:
- Added a test case for tool.extensions. 
- Updated v2 report_stage_test. Now it's actually testing v2 sarif reports.
- Fixed v2 tests that failed.
- Updated makefile to also run v2 tests.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
