### PR TITLE
fix: don't omit zero ruleIndex

### DIFF
--- a/pkg/report/v210/sarif/result.go
+++ b/pkg/report/v210/sarif/result.go
@@ -72,7 +72,7 @@ type Result struct {
 	RuleID *string `json:"ruleId,omitempty"`
 
 	// The index within the tool component rules array of the rule object associated with this result.
-	RuleIndex int `json:"ruleIndex,omitempty"`
+	RuleIndex int `json:"ruleIndex"`
 
 	// An array of 'stack' objects relevant to the result.
 	Stacks []*Stack `json:"stacks,omitempty"`


### PR DESCRIPTION
Hi @owenrumney, 

I found another issue in v3 and a potential bug in the code generator you mentioned in https://github.com/owenrumney/go-sarif/pull/93.

The `ruleIndex` property of a `result` is currently omitted when empty, even though `0` is a valid value and should be included in the SARIF JSON. A quick fix is to remove the `omitempty` tag from the `Result` struct field, but in v2 this was addressed by changing the type from `int` (`uint`) to `*int` (`*uint`), ensuring the field is omitted only when truly unset.  


Some SARIF integer fields also default to `-1` and are omitted when `0`, similar to `ruleIndex`. I haven't fully investigated whether the same fix should be applied to them, but I'm fairly sure about `result.rank`, as it can also be `0`.  

Let me know what you think!