### PR TITLE
fix: Don't omit empty for default value items

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/owenrumney/go-sarif/v3)](https://goreportcard.com/report/github.com/owenrumney/go-sarif/v3)
 [![Github Release](https://img.shields.io/github/release/owenrumney/go-sarif.svg)](https://github.com/owenrumney/go-sarif/releases)
 
+>[!IMPORTANT]
+>go-sarif is true to the specifications with a single deviation to accomodate GitHub processing of SARIF reports. the `run.Results` attribute is not a required field per the spec but is required by GitHub to successfully process the report. To that end, the `omitEmpty` is removed on the attribute.
+
+
 ## Overview
 
 SARIF is the Static Analysis Results Interchange Format, this project seeks to provide a simple interface to generate reports in the SARIF format.

--- a/pkg/report/v210/sarif/artifact.go
+++ b/pkg/report/v210/sarif/artifact.go
@@ -36,7 +36,7 @@ type Artifact struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// The role or roles played by the artifact in the analysis.
-	Roles []string `json:"roles,omitempty"`
+	Roles []string `json:"roles"`
 
 	// Specifies the source language for any artifact object that refers to a text file that contains source code.
 	SourceLanguage *string `json:"sourceLanguage,omitempty"`

--- a/pkg/report/v210/sarif/attachment.go
+++ b/pkg/report/v210/sarif/attachment.go
@@ -12,10 +12,10 @@ type Attachment struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of rectangles specifying areas of interest within the image.
-	Rectangles []*Rectangle `json:"rectangles,omitempty"`
+	Rectangles []*Rectangle `json:"rectangles"`
 
 	// An array of regions of interest within the attachment.
-	Regions []*Region `json:"regions,omitempty"`
+	Regions []*Region `json:"regions"`
 }
 
 // NewAttachment - creates a new

--- a/pkg/report/v210/sarif/conversion.go
+++ b/pkg/report/v210/sarif/conversion.go
@@ -3,7 +3,7 @@ package sarif
 // Conversion - Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.
 type Conversion struct {
 	// The locations of the analysis tool's per-run log files.
-	AnalysisToolLogFiles []*ArtifactLocation `json:"analysisToolLogFiles,omitempty"`
+	AnalysisToolLogFiles []*ArtifactLocation `json:"analysisToolLogFiles"`
 
 	// An invocation object that describes the invocation of the converter.
 	Invocation *Invocation `json:"invocation,omitempty"`

--- a/pkg/report/v210/sarif/exception.go
+++ b/pkg/report/v210/sarif/exception.go
@@ -3,7 +3,7 @@ package sarif
 // Exception - Describes a runtime exception encountered during the execution of an analysis tool.
 type Exception struct {
 	// An array of exception objects each of which is considered a cause of this exception.
-	InnerExceptions []*Exception `json:"innerExceptions,omitempty"`
+	InnerExceptions []*Exception `json:"innerExceptions"`
 
 	// A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal.
 	Kind *string `json:"kind,omitempty"`

--- a/pkg/report/v210/sarif/external_properties.go
+++ b/pkg/report/v210/sarif/external_properties.go
@@ -3,7 +3,7 @@ package sarif
 // ExternalProperties - The top-level element of an external property file.
 type ExternalProperties struct {
 	// Addresses that will be merged with a separate run.
-	Addresses []*Address `json:"addresses,omitempty"`
+	Addresses []*Address `json:"addresses"`
 
 	// An array of artifact objects that will be merged with a separate run.
 	Artifacts []*Artifact `json:"artifacts,omitempty"`
@@ -15,31 +15,31 @@ type ExternalProperties struct {
 	Driver *ToolComponent `json:"driver,omitempty"`
 
 	// Tool extensions that will be merged with a separate run.
-	Extensions []*ToolComponent `json:"extensions,omitempty"`
+	Extensions []*ToolComponent `json:"extensions"`
 
 	// Key/value pairs that provide additional information that will be merged with a separate run.
 	ExternalizedProperties *PropertyBag `json:"externalizedProperties,omitempty"`
 
 	// An array of graph objects that will be merged with a separate run.
-	Graphs []*Graph `json:"graphs,omitempty"`
+	Graphs []*Graph `json:"graphs"`
 
 	// A stable, unique identifier for this external properties object, in the form of a GUID.
 	GuID *string `json:"guid,omitempty"`
 
 	// Describes the invocation of the analysis tool that will be merged with a separate run.
-	Invocations []*Invocation `json:"invocations,omitempty"`
+	Invocations []*Invocation `json:"invocations"`
 
 	// An array of logical locations such as namespaces, types or functions that will be merged with a separate run.
-	LogicalLocations []*LogicalLocation `json:"logicalLocations,omitempty"`
+	LogicalLocations []*LogicalLocation `json:"logicalLocations"`
 
 	// Tool policies that will be merged with a separate run.
-	Policies []*ToolComponent `json:"policies,omitempty"`
+	Policies []*ToolComponent `json:"policies"`
 
 	// Key/value pairs that provide additional information about the external properties.
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of result objects that will be merged with a separate run.
-	Results []*Result `json:"results,omitempty"`
+	Results []*Result `json:"results"`
 
 	// A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.
 	RunGuID *string `json:"runGuid,omitempty"`
@@ -48,22 +48,22 @@ type ExternalProperties struct {
 	Schema *string `json:"schema,omitempty"`
 
 	// Tool taxonomies that will be merged with a separate run.
-	Taxonomies []*ToolComponent `json:"taxonomies,omitempty"`
+	Taxonomies []*ToolComponent `json:"taxonomies"`
 
 	// An array of threadFlowLocation objects that will be merged with a separate run.
-	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations,omitempty"`
+	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations"`
 
 	// Tool translations that will be merged with a separate run.
-	Translations []*ToolComponent `json:"translations,omitempty"`
+	Translations []*ToolComponent `json:"translations"`
 
 	// The SARIF format version of this external properties object.
 	Version *string `json:"version,omitempty"`
 
 	// Requests that will be merged with a separate run.
-	WebRequests []*WebRequest `json:"webRequests,omitempty"`
+	WebRequests []*WebRequest `json:"webRequests"`
 
 	// Responses that will be merged with a separate run.
-	WebResponses []*WebResponse `json:"webResponses,omitempty"`
+	WebResponses []*WebResponse `json:"webResponses"`
 }
 
 // NewExternalProperties - creates a new

--- a/pkg/report/v210/sarif/external_property_file_references.go
+++ b/pkg/report/v210/sarif/external_property_file_references.go
@@ -3,10 +3,10 @@ package sarif
 // ExternalPropertyFileReferences - References to external property files that should be inlined with the content of a root log file.
 type ExternalPropertyFileReferences struct {
 	// An array of external property files containing run.addresses arrays to be merged with the root log file.
-	Addresses []*ExternalPropertyFileReference `json:"addresses,omitempty"`
+	Addresses []*ExternalPropertyFileReference `json:"addresses"`
 
 	// An array of external property files containing run.artifacts arrays to be merged with the root log file.
-	Artifacts []*ExternalPropertyFileReference `json:"artifacts,omitempty"`
+	Artifacts []*ExternalPropertyFileReference `json:"artifacts"`
 
 	// An external property file containing a run.conversion object to be merged with the root log file.
 	Conversion *ExternalPropertyFileReference `json:"conversion,omitempty"`
@@ -15,43 +15,43 @@ type ExternalPropertyFileReferences struct {
 	Driver *ExternalPropertyFileReference `json:"driver,omitempty"`
 
 	// An array of external property files containing run.extensions arrays to be merged with the root log file.
-	Extensions []*ExternalPropertyFileReference `json:"extensions,omitempty"`
+	Extensions []*ExternalPropertyFileReference `json:"extensions"`
 
 	// An external property file containing a run.properties object to be merged with the root log file.
 	ExternalizedProperties *ExternalPropertyFileReference `json:"externalizedProperties,omitempty"`
 
 	// An array of external property files containing a run.graphs object to be merged with the root log file.
-	Graphs []*ExternalPropertyFileReference `json:"graphs,omitempty"`
+	Graphs []*ExternalPropertyFileReference `json:"graphs"`
 
 	// An array of external property files containing run.invocations arrays to be merged with the root log file.
-	Invocations []*ExternalPropertyFileReference `json:"invocations,omitempty"`
+	Invocations []*ExternalPropertyFileReference `json:"invocations"`
 
 	// An array of external property files containing run.logicalLocations arrays to be merged with the root log file.
-	LogicalLocations []*ExternalPropertyFileReference `json:"logicalLocations,omitempty"`
+	LogicalLocations []*ExternalPropertyFileReference `json:"logicalLocations"`
 
 	// An array of external property files containing run.policies arrays to be merged with the root log file.
-	Policies []*ExternalPropertyFileReference `json:"policies,omitempty"`
+	Policies []*ExternalPropertyFileReference `json:"policies"`
 
 	// Key/value pairs that provide additional information about the external property files.
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of external property files containing run.results arrays to be merged with the root log file.
-	Results []*ExternalPropertyFileReference `json:"results,omitempty"`
+	Results []*ExternalPropertyFileReference `json:"results"`
 
 	// An array of external property files containing run.taxonomies arrays to be merged with the root log file.
-	Taxonomies []*ExternalPropertyFileReference `json:"taxonomies,omitempty"`
+	Taxonomies []*ExternalPropertyFileReference `json:"taxonomies"`
 
 	// An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.
-	ThreadFlowLocations []*ExternalPropertyFileReference `json:"threadFlowLocations,omitempty"`
+	ThreadFlowLocations []*ExternalPropertyFileReference `json:"threadFlowLocations"`
 
 	// An array of external property files containing run.translations arrays to be merged with the root log file.
-	Translations []*ExternalPropertyFileReference `json:"translations,omitempty"`
+	Translations []*ExternalPropertyFileReference `json:"translations"`
 
 	// An array of external property files containing run.requests arrays to be merged with the root log file.
-	WebRequests []*ExternalPropertyFileReference `json:"webRequests,omitempty"`
+	WebRequests []*ExternalPropertyFileReference `json:"webRequests"`
 
 	// An array of external property files containing run.responses arrays to be merged with the root log file.
-	WebResponses []*ExternalPropertyFileReference `json:"webResponses,omitempty"`
+	WebResponses []*ExternalPropertyFileReference `json:"webResponses"`
 }
 
 // NewExternalPropertyFileReferences - creates a new

--- a/pkg/report/v210/sarif/graph.go
+++ b/pkg/report/v210/sarif/graph.go
@@ -6,10 +6,10 @@ type Graph struct {
 	Description *Message `json:"description,omitempty"`
 
 	// An array of edge objects representing the edges of the graph.
-	Edges []*Edge `json:"edges,omitempty"`
+	Edges []*Edge `json:"edges"`
 
 	// An array of node objects representing the nodes of the graph.
-	Nodes []*Node `json:"nodes,omitempty"`
+	Nodes []*Node `json:"nodes"`
 
 	// Key/value pairs that provide additional information about the graph.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v210/sarif/graph_traversal.go
+++ b/pkg/report/v210/sarif/graph_traversal.go
@@ -12,7 +12,7 @@ type GraphTraversal struct {
 	Description *Message `json:"description,omitempty"`
 
 	// The sequences of edges traversed by this graph traversal.
-	EdgeTraversals []*EdgeTraversal `json:"edgeTraversals,omitempty"`
+	EdgeTraversals []*EdgeTraversal `json:"edgeTraversals"`
 
 	// Key/value pairs that provide additional information about the graph traversal.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v210/sarif/invocation.go
+++ b/pkg/report/v210/sarif/invocation.go
@@ -39,7 +39,7 @@ type Invocation struct {
 	Machine *string `json:"machine,omitempty"`
 
 	// An array of configurationOverride objects that describe notifications related runtime overrides.
-	NotificationConfigurationOverrides []*ConfigurationOverride `json:"notificationConfigurationOverrides,omitempty"`
+	NotificationConfigurationOverrides []*ConfigurationOverride `json:"notificationConfigurationOverrides"`
 
 	// The id of the process in which the invocation occurred.
 	ProcessID *int `json:"processId,omitempty"`
@@ -54,7 +54,7 @@ type Invocation struct {
 	ResponseFiles []*ArtifactLocation `json:"responseFiles,omitempty"`
 
 	// An array of configurationOverride objects that describe rules related runtime overrides.
-	RuleConfigurationOverrides []*ConfigurationOverride `json:"ruleConfigurationOverrides,omitempty"`
+	RuleConfigurationOverrides []*ConfigurationOverride `json:"ruleConfigurationOverrides"`
 
 	// The Coordinated Universal Time (UTC) date and time at which the invocation started. See "Date/time properties" in the SARIF spec for the required format.
 	StartTimeUtc *string `json:"startTimeUtc,omitempty"`
@@ -72,10 +72,10 @@ type Invocation struct {
 	StdoutStderr *ArtifactLocation `json:"stdoutStderr,omitempty"`
 
 	// A list of conditions detected by the tool that are relevant to the tool's configuration.
-	ToolConfigurationNotifications []*Notification `json:"toolConfigurationNotifications,omitempty"`
+	ToolConfigurationNotifications []*Notification `json:"toolConfigurationNotifications"`
 
 	// A list of runtime conditions detected by the tool during the analysis.
-	ToolExecutionNotifications []*Notification `json:"toolExecutionNotifications,omitempty"`
+	ToolExecutionNotifications []*Notification `json:"toolExecutionNotifications"`
 
 	// The working directory for the invocation.
 	WorkingDirectory *ArtifactLocation `json:"workingDirectory,omitempty"`

--- a/pkg/report/v210/sarif/location.go
+++ b/pkg/report/v210/sarif/location.go
@@ -3,13 +3,13 @@ package sarif
 // Location - A location within a programming artifact.
 type Location struct {
 	// A set of regions relevant to the location.
-	Annotations []*Region `json:"annotations,omitempty"`
+	Annotations []*Region `json:"annotations"`
 
 	// Value that distinguishes this location from all other locations within a single result object.
 	ID int `json:"id"`
 
 	// The logical locations associated with the result.
-	LogicalLocations []*LogicalLocation `json:"logicalLocations,omitempty"`
+	LogicalLocations []*LogicalLocation `json:"logicalLocations"`
 
 	// A message relevant to the location.
 	Message *Message `json:"message,omitempty"`
@@ -21,7 +21,7 @@ type Location struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of objects that describe relationships between this location and others.
-	Relationships []*LocationRelationship `json:"relationships,omitempty"`
+	Relationships []*LocationRelationship `json:"relationships"`
 }
 
 // NewLocation - creates a new

--- a/pkg/report/v210/sarif/location_relationship.go
+++ b/pkg/report/v210/sarif/location_relationship.go
@@ -6,7 +6,7 @@ type LocationRelationship struct {
 	Description *Message `json:"description,omitempty"`
 
 	// A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.
-	Kinds []string `json:"kinds,omitempty"`
+	Kinds []string `json:"kinds"`
 
 	// Key/value pairs that provide additional information about the location relationship.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v210/sarif/message.go
+++ b/pkg/report/v210/sarif/message.go
@@ -3,7 +3,7 @@ package sarif
 // Message - Encapsulates a message intended to be read by the end user.
 type Message struct {
 	// An array of strings to substitute into the message string.
-	Arguments []string `json:"arguments,omitempty"`
+	Arguments []string `json:"arguments"`
 
 	// The identifier for this message.
 	ID *string `json:"id,omitempty"`

--- a/pkg/report/v210/sarif/node.go
+++ b/pkg/report/v210/sarif/node.go
@@ -3,7 +3,7 @@ package sarif
 // Node - Represents a node in a graph.
 type Node struct {
 	// Array of child nodes.
-	Children []*Node `json:"children,omitempty"`
+	Children []*Node `json:"children"`
 
 	// A string that uniquely identifies the node within its graph.
 	ID *string `json:"id,omitempty"`

--- a/pkg/report/v210/sarif/notification.go
+++ b/pkg/report/v210/sarif/notification.go
@@ -12,10 +12,10 @@ type Notification struct {
 	Exception *Exception `json:"exception,omitempty"`
 
 	// A value specifying the severity level of the notification.
-	Level string `json:"level,omitempty"`
+	Level string `json:"level"`
 
 	// The locations relevant to this notification.
-	Locations []*Location `json:"locations,omitempty"`
+	Locations []*Location `json:"locations"`
 
 	// A message that describes the condition that was encountered.
 	Message *Message `json:"message,omitempty"`

--- a/pkg/report/v210/sarif/property_bag.go
+++ b/pkg/report/v210/sarif/property_bag.go
@@ -6,7 +6,7 @@ type PropertyBag struct {
 	Properties Properties `json:"properties,omitempty"`
 
 	// A set of distinct strings that provide additional information.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 }
 
 // NewPropertyBag - creates a new

--- a/pkg/report/v210/sarif/reporting_configuration.go
+++ b/pkg/report/v210/sarif/reporting_configuration.go
@@ -3,10 +3,10 @@ package sarif
 // ReportingConfiguration - Information about a rule or notification that can be configured at runtime.
 type ReportingConfiguration struct {
 	// Specifies whether the report may be produced during the scan.
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 
 	// Specifies the failure level for the report.
-	Level string `json:"level,omitempty"`
+	Level string `json:"level"`
 
 	// Contains configuration information specific to a report.
 	Parameters *PropertyBag `json:"parameters,omitempty"`

--- a/pkg/report/v210/sarif/reporting_descriptor.go
+++ b/pkg/report/v210/sarif/reporting_descriptor.go
@@ -39,7 +39,7 @@ type ReportingDescriptor struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of objects that describe relationships between this reporting descriptor and others.
-	Relationships []*ReportingDescriptorRelationship `json:"relationships,omitempty"`
+	Relationships []*ReportingDescriptorRelationship `json:"relationships"`
 
 	// A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text.
 	ShortDescription *MultiformatMessageString `json:"shortDescription,omitempty"`

--- a/pkg/report/v210/sarif/reporting_descriptor_relationship.go
+++ b/pkg/report/v210/sarif/reporting_descriptor_relationship.go
@@ -6,7 +6,7 @@ type ReportingDescriptorRelationship struct {
 	Description *Message `json:"description,omitempty"`
 
 	// A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.
-	Kinds []string `json:"kinds,omitempty"`
+	Kinds []string `json:"kinds"`
 
 	// Key/value pairs that provide additional information about the reporting descriptor reference.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v210/sarif/result.go
+++ b/pkg/report/v210/sarif/result.go
@@ -12,25 +12,25 @@ type Result struct {
 	AnalysisTarget *ArtifactLocation `json:"analysisTarget,omitempty"`
 
 	// A set of artifacts relevant to the result.
-	Attachments []*Attachment `json:"attachments,omitempty"`
+	Attachments []*Attachment `json:"attachments"`
 
 	// The state of a result relative to a baseline of a previous run.
 	BaselineState *string `json:"baselineState,omitempty"`
 
 	// An array of 'codeFlow' objects relevant to the result.
-	CodeFlows []*CodeFlow `json:"codeFlows,omitempty"`
+	CodeFlows []*CodeFlow `json:"codeFlows"`
 
 	// A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.
 	CorrelationGuID *string `json:"correlationGuid,omitempty"`
 
 	// An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.
-	Fixes []*Fix `json:"fixes,omitempty"`
+	Fixes []*Fix `json:"fixes"`
 
 	// An array of one or more unique 'graphTraversal' objects.
-	GraphTraversals []*GraphTraversal `json:"graphTraversals,omitempty"`
+	GraphTraversals []*GraphTraversal `json:"graphTraversals"`
 
 	// An array of zero or more unique graph objects associated with the result.
-	Graphs []*Graph `json:"graphs,omitempty"`
+	Graphs []*Graph `json:"graphs"`
 
 	// A stable, unique identifier for the result in the form of a GUID.
 	GuID *string `json:"guid,omitempty"`
@@ -39,13 +39,13 @@ type Result struct {
 	HostedViewerURI *string `json:"hostedViewerUri,omitempty"`
 
 	// A value that categorizes results by evaluation state.
-	Kind string `json:"kind,omitempty"`
+	Kind string `json:"kind"`
 
 	// A value specifying the severity level of the result.
-	Level string `json:"level,omitempty"`
+	Level string `json:"level"`
 
 	// The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.
-	Locations []*Location `json:"locations,omitempty"`
+	Locations []*Location `json:"locations"`
 
 	// A message that describes the result. The first sentence of the message only will be displayed when visible space is limited.
 	Message *Message `json:"message,omitempty"`
@@ -63,7 +63,7 @@ type Result struct {
 	Rank float64 `json:"rank"`
 
 	// A set of locations relevant to this result.
-	RelatedLocations []*Location `json:"relatedLocations,omitempty"`
+	RelatedLocations []*Location `json:"relatedLocations"`
 
 	// A reference used to locate the rule descriptor relevant to this result.
 	Rule *ReportingDescriptorReference `json:"rule,omitempty"`
@@ -75,13 +75,13 @@ type Result struct {
 	RuleIndex int `json:"ruleIndex"`
 
 	// An array of 'stack' objects relevant to the result.
-	Stacks []*Stack `json:"stacks,omitempty"`
+	Stacks []*Stack `json:"stacks"`
 
 	// A set of suppressions relevant to this result.
 	Suppressions []*Suppression `json:"suppressions,omitempty"`
 
 	// An array of references to taxonomy reporting descriptors that are applicable to the result.
-	Taxa []*ReportingDescriptorReference `json:"taxa,omitempty"`
+	Taxa []*ReportingDescriptorReference `json:"taxa"`
 
 	// A web request associated with this result.
 	WebRequest *WebRequest `json:"webRequest,omitempty"`

--- a/pkg/report/v210/sarif/result_provenance.go
+++ b/pkg/report/v210/sarif/result_provenance.go
@@ -3,7 +3,7 @@ package sarif
 // ResultProvenance - Contains information about how and when a result was detected.
 type ResultProvenance struct {
 	// An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.
-	ConversionSources []*PhysicalLocation `json:"conversionSources,omitempty"`
+	ConversionSources []*PhysicalLocation `json:"conversionSources"`
 
 	// A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.
 	FirstDetectionRunGuID *string `json:"firstDetectionRunGuid,omitempty"`

--- a/pkg/report/v210/sarif/run.go
+++ b/pkg/report/v210/sarif/run.go
@@ -6,7 +6,7 @@ type Run struct {
 	OriginalUriBaseIds map[string]ArtifactLocation `json:"originalUriBaseIds,omitempty"`
 
 	// Addresses associated with this run instance, if any.
-	Addresses []*Address `json:"addresses,omitempty"`
+	Addresses []*Address `json:"addresses"`
 
 	// An array of artifact objects relevant to the run.
 	Artifacts []*Artifact `json:"artifacts,omitempty"`
@@ -33,58 +33,58 @@ type Run struct {
 	ExternalPropertyFileReferences *ExternalPropertyFileReferences `json:"externalPropertyFileReferences,omitempty"`
 
 	// An array of zero or more unique graph objects associated with the run.
-	Graphs []*Graph `json:"graphs,omitempty"`
+	Graphs []*Graph `json:"graphs"`
 
 	// Describes the invocation of the analysis tool.
-	Invocations []*Invocation `json:"invocations,omitempty"`
+	Invocations []*Invocation `json:"invocations"`
 
 	// The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).
-	Language string `json:"language,omitempty"`
+	Language string `json:"language"`
 
 	// An array of logical locations such as namespaces, types or functions.
-	LogicalLocations []*LogicalLocation `json:"logicalLocations,omitempty"`
+	LogicalLocations []*LogicalLocation `json:"logicalLocations"`
 
 	// An ordered list of character sequences that were treated as line breaks when computing region information for the run.
-	NewlineSequences []string `json:"newlineSequences,omitempty"`
+	NewlineSequences []string `json:"newlineSequences"`
 
 	// Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).
-	Policies []*ToolComponent `json:"policies,omitempty"`
+	Policies []*ToolComponent `json:"policies"`
 
 	// Key/value pairs that provide additional information about the run.
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of strings used to replace sensitive information in a redaction-aware property.
-	RedactionTokens []string `json:"redactionTokens,omitempty"`
+	RedactionTokens []string `json:"redactionTokens"`
 
 	// The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.
-	Results []*Result `json:"results,omitempty"`
+	Results []*Result `json:"results"`
 
 	// Automation details that describe the aggregate of runs to which this run belongs.
-	RunAggregates []*RunAutomationDetails `json:"runAggregates,omitempty"`
+	RunAggregates []*RunAutomationDetails `json:"runAggregates"`
 
 	// A specialLocations object that defines locations of special significance to SARIF consumers.
 	SpecialLocations *SpecialLocations `json:"specialLocations,omitempty"`
 
 	// An array of toolComponent objects relevant to a taxonomy in which results are categorized.
-	Taxonomies []*ToolComponent `json:"taxonomies,omitempty"`
+	Taxonomies []*ToolComponent `json:"taxonomies"`
 
 	// An array of threadFlowLocation objects cached at run level.
-	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations,omitempty"`
+	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations"`
 
 	// Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.
 	Tool *Tool `json:"tool,omitempty"`
 
 	// The set of available translations of the localized data provided by the tool.
-	Translations []*ToolComponent `json:"translations,omitempty"`
+	Translations []*ToolComponent `json:"translations"`
 
 	// Specifies the revision in version control of the artifacts that were scanned.
-	VersionControlProvenance []*VersionControlDetails `json:"versionControlProvenance,omitempty"`
+	VersionControlProvenance []*VersionControlDetails `json:"versionControlProvenance"`
 
 	// An array of request objects cached at run level.
-	WebRequests []*WebRequest `json:"webRequests,omitempty"`
+	WebRequests []*WebRequest `json:"webRequests"`
 
 	// An array of response objects cached at run level.
-	WebResponses []*WebResponse `json:"webResponses,omitempty"`
+	WebResponses []*WebResponse `json:"webResponses"`
 }
 
 // NewRun - creates a new

--- a/pkg/report/v210/sarif/stack_frame.go
+++ b/pkg/report/v210/sarif/stack_frame.go
@@ -9,7 +9,7 @@ type StackFrame struct {
 	Module *string `json:"module,omitempty"`
 
 	// The parameters of the call that is executing.
-	Parameters []string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters"`
 
 	// Key/value pairs that provide additional information about the stack frame.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v210/sarif/thread_flow_location.go
+++ b/pkg/report/v210/sarif/thread_flow_location.go
@@ -12,13 +12,13 @@ type ThreadFlowLocation struct {
 	ExecutionTimeUtc *string `json:"executionTimeUtc,omitempty"`
 
 	// Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is "essential", "important", "unimportant". Default: "important".
-	Importance string `json:"importance,omitempty"`
+	Importance string `json:"importance"`
 
 	// The index within the run threadFlowLocations array.
 	Index int `json:"index"`
 
 	// A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.
-	Kinds []string `json:"kinds,omitempty"`
+	Kinds []string `json:"kinds"`
 
 	// The code location.
 	Location *Location `json:"location,omitempty"`
@@ -36,7 +36,7 @@ type ThreadFlowLocation struct {
 	Stack *Stack `json:"stack,omitempty"`
 
 	// An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.
-	Taxa []*ReportingDescriptorReference `json:"taxa,omitempty"`
+	Taxa []*ReportingDescriptorReference `json:"taxa"`
 
 	// A web request associated with this thread flow location.
 	WebRequest *WebRequest `json:"webRequest,omitempty"`

--- a/pkg/report/v210/sarif/tool.go
+++ b/pkg/report/v210/sarif/tool.go
@@ -6,7 +6,7 @@ type Tool struct {
 	Driver *ToolComponent `json:"driver,omitempty"`
 
 	// Tool extensions that contributed to or reconfigured the analysis tool that was run.
-	Extensions []*ToolComponent `json:"extensions,omitempty"`
+	Extensions []*ToolComponent `json:"extensions"`
 
 	// Key/value pairs that provide additional information about the tool.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v210/sarif/tool_component.go
+++ b/pkg/report/v210/sarif/tool_component.go
@@ -9,7 +9,7 @@ type ToolComponent struct {
 	AssociatedComponent *ToolComponentReference `json:"associatedComponent,omitempty"`
 
 	// The kinds of data contained in this object.
-	Contents []string `json:"contents,omitempty"`
+	Contents []string `json:"contents"`
 
 	// The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).
 	DottedQuadFileVersion *string `json:"dottedQuadFileVersion,omitempty"`
@@ -30,16 +30,16 @@ type ToolComponent struct {
 	InformationURI *string `json:"informationUri,omitempty"`
 
 	// Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.
-	IsComprehensive bool `json:"isComprehensive,omitempty"`
+	IsComprehensive bool `json:"isComprehensive"`
 
 	// The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).
-	Language string `json:"language,omitempty"`
+	Language string `json:"language"`
 
 	// The semantic version of the localized strings defined in this component; maintained by components that provide translations.
 	LocalizedDataSemanticVersion *string `json:"localizedDataSemanticVersion,omitempty"`
 
 	// An array of the artifactLocation objects associated with the tool component.
-	Locations []*ArtifactLocation `json:"locations,omitempty"`
+	Locations []*ArtifactLocation `json:"locations"`
 
 	// The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.
 	MinimumRequiredLocalizedDataSemanticVersion *string `json:"minimumRequiredLocalizedDataSemanticVersion,omitempty"`
@@ -48,7 +48,7 @@ type ToolComponent struct {
 	Name *string `json:"name,omitempty"`
 
 	// An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.
-	Notifications []*ReportingDescriptor `json:"notifications,omitempty"`
+	Notifications []*ReportingDescriptor `json:"notifications"`
 
 	// The organization or company that produced the tool component.
 	Organization *string `json:"organization,omitempty"`
@@ -66,7 +66,7 @@ type ToolComponent struct {
 	ReleaseDateUtc *string `json:"releaseDateUtc,omitempty"`
 
 	// An array of reportingDescriptor objects relevant to the analysis performed by the tool component.
-	Rules []*ReportingDescriptor `json:"rules,omitempty"`
+	Rules []*ReportingDescriptor `json:"rules"`
 
 	// The tool component version in the format specified by Semantic Versioning 2.0.
 	SemanticVersion *string `json:"semanticVersion,omitempty"`
@@ -75,10 +75,10 @@ type ToolComponent struct {
 	ShortDescription *MultiformatMessageString `json:"shortDescription,omitempty"`
 
 	// An array of toolComponentReference objects to declare the taxonomies supported by the tool component.
-	SupportedTaxonomies []*ToolComponentReference `json:"supportedTaxonomies,omitempty"`
+	SupportedTaxonomies []*ToolComponentReference `json:"supportedTaxonomies"`
 
 	// An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.
-	Taxa []*ReportingDescriptor `json:"taxa,omitempty"`
+	Taxa []*ReportingDescriptor `json:"taxa"`
 
 	// Translation metadata, required for a translation, not populated by other component types.
 	TranslationMetadata *TranslationMetadata `json:"translationMetadata,omitempty"`

--- a/pkg/report/v210/sarif/web_response.go
+++ b/pkg/report/v210/sarif/web_response.go
@@ -12,7 +12,7 @@ type WebResponse struct {
 	Index int `json:"index"`
 
 	// Specifies whether a response was received from the server.
-	NoResponseReceived bool `json:"noResponseReceived,omitempty"`
+	NoResponseReceived bool `json:"noResponseReceived"`
 
 	// Key/value pairs that provide additional information about the response.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/artifact.go
+++ b/pkg/report/v22/sarif/artifact.go
@@ -36,7 +36,7 @@ type Artifact struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// The role or roles played by the artifact in the analysis.
-	Roles []string `json:"roles,omitempty"`
+	Roles []string `json:"roles"`
 
 	// Specifies the source language for any artifact object that refers to a text file that contains source code.
 	SourceLanguage *string `json:"sourceLanguage,omitempty"`

--- a/pkg/report/v22/sarif/attachment.go
+++ b/pkg/report/v22/sarif/attachment.go
@@ -12,10 +12,10 @@ type Attachment struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of rectangles specifying areas of interest within the image.
-	Rectangles []*Rectangle `json:"rectangles,omitempty"`
+	Rectangles []*Rectangle `json:"rectangles"`
 
 	// An array of regions of interest within the attachment.
-	Regions []*Region `json:"regions,omitempty"`
+	Regions []*Region `json:"regions"`
 }
 
 // NewAttachment - creates a new

--- a/pkg/report/v22/sarif/conversion.go
+++ b/pkg/report/v22/sarif/conversion.go
@@ -3,7 +3,7 @@ package sarif
 // Conversion - Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.
 type Conversion struct {
 	// The locations of the analysis tool's per-run log files.
-	AnalysisToolLogFiles []*ArtifactLocation `json:"analysisToolLogFiles,omitempty"`
+	AnalysisToolLogFiles []*ArtifactLocation `json:"analysisToolLogFiles"`
 
 	// An invocation object that describes the invocation of the converter.
 	Invocation *Invocation `json:"invocation,omitempty"`

--- a/pkg/report/v22/sarif/exception.go
+++ b/pkg/report/v22/sarif/exception.go
@@ -3,7 +3,7 @@ package sarif
 // Exception - Describes a runtime exception encountered during the execution of an analysis tool.
 type Exception struct {
 	// An array of exception objects each of which is considered a cause of this exception.
-	InnerExceptions []*Exception `json:"innerExceptions,omitempty"`
+	InnerExceptions []*Exception `json:"innerExceptions"`
 
 	// A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal.
 	Kind *string `json:"kind,omitempty"`

--- a/pkg/report/v22/sarif/external_properties.go
+++ b/pkg/report/v22/sarif/external_properties.go
@@ -3,7 +3,7 @@ package sarif
 // ExternalProperties - The top-level element of an external property file.
 type ExternalProperties struct {
 	// Addresses that will be merged with a separate run.
-	Addresses []*Address `json:"addresses,omitempty"`
+	Addresses []*Address `json:"addresses"`
 
 	// An array of artifact objects that will be merged with a separate run.
 	Artifacts []*Artifact `json:"artifacts,omitempty"`
@@ -15,31 +15,31 @@ type ExternalProperties struct {
 	Driver *ToolComponent `json:"driver,omitempty"`
 
 	// Tool extensions that will be merged with a separate run.
-	Extensions []*ToolComponent `json:"extensions,omitempty"`
+	Extensions []*ToolComponent `json:"extensions"`
 
 	// Key/value pairs that provide additional information that will be merged with a separate run.
 	ExternalizedProperties *PropertyBag `json:"externalizedProperties,omitempty"`
 
 	// An array of graph objects that will be merged with a separate run.
-	Graphs []*Graph `json:"graphs,omitempty"`
+	Graphs []*Graph `json:"graphs"`
 
 	// A stable, unique identifier for this external properties object, in the form of a GUID.
 	Guid *Guid `json:"guid,omitempty"`
 
 	// Describes the invocation of the analysis tool that will be merged with a separate run.
-	Invocations []*Invocation `json:"invocations,omitempty"`
+	Invocations []*Invocation `json:"invocations"`
 
 	// An array of logical locations such as namespaces, types or functions that will be merged with a separate run.
-	LogicalLocations []*LogicalLocation `json:"logicalLocations,omitempty"`
+	LogicalLocations []*LogicalLocation `json:"logicalLocations"`
 
 	// Tool policies that will be merged with a separate run.
-	Policies []*ToolComponent `json:"policies,omitempty"`
+	Policies []*ToolComponent `json:"policies"`
 
 	// Key/value pairs that provide additional information about the external properties.
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of result objects that will be merged with a separate run.
-	Results []*Result `json:"results,omitempty"`
+	Results []*Result `json:"results"`
 
 	// A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.
 	RunGuID *string `json:"runGuid,omitempty"`
@@ -48,22 +48,22 @@ type ExternalProperties struct {
 	Schema *string `json:"schema,omitempty"`
 
 	// Tool taxonomies that will be merged with a separate run.
-	Taxonomies []*ToolComponent `json:"taxonomies,omitempty"`
+	Taxonomies []*ToolComponent `json:"taxonomies"`
 
 	// An array of threadFlowLocation objects that will be merged with a separate run.
-	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations,omitempty"`
+	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations"`
 
 	// Tool translations that will be merged with a separate run.
-	Translations []*ToolComponent `json:"translations,omitempty"`
+	Translations []*ToolComponent `json:"translations"`
 
 	// The SARIF format version of this external properties object.
 	Version *string `json:"version,omitempty"`
 
 	// Requests that will be merged with a separate run.
-	WebRequests []*WebRequest `json:"webRequests,omitempty"`
+	WebRequests []*WebRequest `json:"webRequests"`
 
 	// Responses that will be merged with a separate run.
-	WebResponses []*WebResponse `json:"webResponses,omitempty"`
+	WebResponses []*WebResponse `json:"webResponses"`
 }
 
 // NewExternalProperties - creates a new

--- a/pkg/report/v22/sarif/external_property_file_references.go
+++ b/pkg/report/v22/sarif/external_property_file_references.go
@@ -3,10 +3,10 @@ package sarif
 // ExternalPropertyFileReferences - References to external property files that should be inlined with the content of a root log file.
 type ExternalPropertyFileReferences struct {
 	// An array of external property files containing run.addresses arrays to be merged with the root log file.
-	Addresses []*ExternalPropertyFileReference `json:"addresses,omitempty"`
+	Addresses []*ExternalPropertyFileReference `json:"addresses"`
 
 	// An array of external property files containing run.artifacts arrays to be merged with the root log file.
-	Artifacts []*ExternalPropertyFileReference `json:"artifacts,omitempty"`
+	Artifacts []*ExternalPropertyFileReference `json:"artifacts"`
 
 	// An external property file containing a run.conversion object to be merged with the root log file.
 	Conversion *ExternalPropertyFileReference `json:"conversion,omitempty"`
@@ -15,43 +15,43 @@ type ExternalPropertyFileReferences struct {
 	Driver *ExternalPropertyFileReference `json:"driver,omitempty"`
 
 	// An array of external property files containing run.extensions arrays to be merged with the root log file.
-	Extensions []*ExternalPropertyFileReference `json:"extensions,omitempty"`
+	Extensions []*ExternalPropertyFileReference `json:"extensions"`
 
 	// An external property file containing a run.properties object to be merged with the root log file.
 	ExternalizedProperties *ExternalPropertyFileReference `json:"externalizedProperties,omitempty"`
 
 	// An array of external property files containing a run.graphs object to be merged with the root log file.
-	Graphs []*ExternalPropertyFileReference `json:"graphs,omitempty"`
+	Graphs []*ExternalPropertyFileReference `json:"graphs"`
 
 	// An array of external property files containing run.invocations arrays to be merged with the root log file.
-	Invocations []*ExternalPropertyFileReference `json:"invocations,omitempty"`
+	Invocations []*ExternalPropertyFileReference `json:"invocations"`
 
 	// An array of external property files containing run.logicalLocations arrays to be merged with the root log file.
-	LogicalLocations []*ExternalPropertyFileReference `json:"logicalLocations,omitempty"`
+	LogicalLocations []*ExternalPropertyFileReference `json:"logicalLocations"`
 
 	// An array of external property files containing run.policies arrays to be merged with the root log file.
-	Policies []*ExternalPropertyFileReference `json:"policies,omitempty"`
+	Policies []*ExternalPropertyFileReference `json:"policies"`
 
 	// Key/value pairs that provide additional information about the external property files.
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of external property files containing run.results arrays to be merged with the root log file.
-	Results []*ExternalPropertyFileReference `json:"results,omitempty"`
+	Results []*ExternalPropertyFileReference `json:"results"`
 
 	// An array of external property files containing run.taxonomies arrays to be merged with the root log file.
-	Taxonomies []*ExternalPropertyFileReference `json:"taxonomies,omitempty"`
+	Taxonomies []*ExternalPropertyFileReference `json:"taxonomies"`
 
 	// An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.
-	ThreadFlowLocations []*ExternalPropertyFileReference `json:"threadFlowLocations,omitempty"`
+	ThreadFlowLocations []*ExternalPropertyFileReference `json:"threadFlowLocations"`
 
 	// An array of external property files containing run.translations arrays to be merged with the root log file.
-	Translations []*ExternalPropertyFileReference `json:"translations,omitempty"`
+	Translations []*ExternalPropertyFileReference `json:"translations"`
 
 	// An array of external property files containing run.requests arrays to be merged with the root log file.
-	WebRequests []*ExternalPropertyFileReference `json:"webRequests,omitempty"`
+	WebRequests []*ExternalPropertyFileReference `json:"webRequests"`
 
 	// An array of external property files containing run.responses arrays to be merged with the root log file.
-	WebResponses []*ExternalPropertyFileReference `json:"webResponses,omitempty"`
+	WebResponses []*ExternalPropertyFileReference `json:"webResponses"`
 }
 
 // NewExternalPropertyFileReferences - creates a new

--- a/pkg/report/v22/sarif/graph.go
+++ b/pkg/report/v22/sarif/graph.go
@@ -6,10 +6,10 @@ type Graph struct {
 	Description *Message `json:"description,omitempty"`
 
 	// An array of edge objects representing the edges of the graph.
-	Edges []*Edge `json:"edges,omitempty"`
+	Edges []*Edge `json:"edges"`
 
 	// An array of node objects representing the nodes of the graph.
-	Nodes []*Node `json:"nodes,omitempty"`
+	Nodes []*Node `json:"nodes"`
 
 	// Key/value pairs that provide additional information about the graph.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/graph_traversal.go
+++ b/pkg/report/v22/sarif/graph_traversal.go
@@ -12,7 +12,7 @@ type GraphTraversal struct {
 	Description *Message `json:"description,omitempty"`
 
 	// The sequences of edges traversed by this graph traversal.
-	EdgeTraversals []*EdgeTraversal `json:"edgeTraversals,omitempty"`
+	EdgeTraversals []*EdgeTraversal `json:"edgeTraversals"`
 
 	// Key/value pairs that provide additional information about the graph traversal.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/invocation.go
+++ b/pkg/report/v22/sarif/invocation.go
@@ -39,7 +39,7 @@ type Invocation struct {
 	Machine *string `json:"machine,omitempty"`
 
 	// An array of configurationOverride objects that describe notifications related runtime overrides.
-	NotificationConfigurationOverrides []*ConfigurationOverride `json:"notificationConfigurationOverrides,omitempty"`
+	NotificationConfigurationOverrides []*ConfigurationOverride `json:"notificationConfigurationOverrides"`
 
 	// The id of the process in which the invocation occurred.
 	ProcessID *int `json:"processId,omitempty"`
@@ -54,7 +54,7 @@ type Invocation struct {
 	ResponseFiles []*ArtifactLocation `json:"responseFiles,omitempty"`
 
 	// An array of configurationOverride objects that describe rules related runtime overrides.
-	RuleConfigurationOverrides []*ConfigurationOverride `json:"ruleConfigurationOverrides,omitempty"`
+	RuleConfigurationOverrides []*ConfigurationOverride `json:"ruleConfigurationOverrides"`
 
 	// The Coordinated Universal Time (UTC) date and time at which the invocation started. See "Date/time properties" in the SARIF spec for the required format.
 	StartTimeUtc *string `json:"startTimeUtc,omitempty"`
@@ -72,10 +72,10 @@ type Invocation struct {
 	StdoutStderr *ArtifactLocation `json:"stdoutStderr,omitempty"`
 
 	// A list of conditions detected by the tool that are relevant to the tool's configuration.
-	ToolConfigurationNotifications []*Notification `json:"toolConfigurationNotifications,omitempty"`
+	ToolConfigurationNotifications []*Notification `json:"toolConfigurationNotifications"`
 
 	// A list of runtime conditions detected by the tool during the analysis.
-	ToolExecutionNotifications []*Notification `json:"toolExecutionNotifications,omitempty"`
+	ToolExecutionNotifications []*Notification `json:"toolExecutionNotifications"`
 
 	// The working directory for the invocation.
 	WorkingDirectory *ArtifactLocation `json:"workingDirectory,omitempty"`

--- a/pkg/report/v22/sarif/location.go
+++ b/pkg/report/v22/sarif/location.go
@@ -3,13 +3,13 @@ package sarif
 // Location - A location within a programming artifact.
 type Location struct {
 	// A set of regions relevant to the location.
-	Annotations []*Region `json:"annotations,omitempty"`
+	Annotations []*Region `json:"annotations"`
 
 	// Value that distinguishes this location from all other locations within a single result object.
 	ID int `json:"id"`
 
 	// The logical locations associated with the result.
-	LogicalLocations []*LogicalLocation `json:"logicalLocations,omitempty"`
+	LogicalLocations []*LogicalLocation `json:"logicalLocations"`
 
 	// A message relevant to the location.
 	Message *Message `json:"message,omitempty"`
@@ -21,7 +21,7 @@ type Location struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of objects that describe relationships between this location and others.
-	Relationships []*LocationRelationship `json:"relationships,omitempty"`
+	Relationships []*LocationRelationship `json:"relationships"`
 }
 
 // NewLocation - creates a new

--- a/pkg/report/v22/sarif/location_relationship.go
+++ b/pkg/report/v22/sarif/location_relationship.go
@@ -6,7 +6,7 @@ type LocationRelationship struct {
 	Description *Message `json:"description,omitempty"`
 
 	// A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.
-	Kinds []string `json:"kinds,omitempty"`
+	Kinds []string `json:"kinds"`
 
 	// Key/value pairs that provide additional information about the location relationship.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/message.go
+++ b/pkg/report/v22/sarif/message.go
@@ -3,7 +3,7 @@ package sarif
 // Message - Encapsulates a message intended to be read by the end user.
 type Message struct {
 	// An array of strings to substitute into the message string.
-	Arguments []string `json:"arguments,omitempty"`
+	Arguments []string `json:"arguments"`
 
 	// The identifier for this message.
 	ID *string `json:"id,omitempty"`

--- a/pkg/report/v22/sarif/node.go
+++ b/pkg/report/v22/sarif/node.go
@@ -3,7 +3,7 @@ package sarif
 // Node - Represents a node in a graph.
 type Node struct {
 	// Array of child nodes.
-	Children []*Node `json:"children,omitempty"`
+	Children []*Node `json:"children"`
 
 	// A string that uniquely identifies the node within its graph.
 	ID *string `json:"id,omitempty"`

--- a/pkg/report/v22/sarif/notification.go
+++ b/pkg/report/v22/sarif/notification.go
@@ -12,10 +12,10 @@ type Notification struct {
 	Exception *Exception `json:"exception,omitempty"`
 
 	// A value specifying the severity level of the notification.
-	Level string `json:"level,omitempty"`
+	Level string `json:"level"`
 
 	// The locations relevant to this notification.
-	Locations []*Location `json:"locations,omitempty"`
+	Locations []*Location `json:"locations"`
 
 	// A message that describes the condition that was encountered.
 	Message *Message `json:"message,omitempty"`
@@ -24,7 +24,7 @@ type Notification struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// A set of locations relevant to this notification.
-	RelatedLocations []*Location `json:"relatedLocations,omitempty"`
+	RelatedLocations []*Location `json:"relatedLocations"`
 
 	// The thread identifier of the code that generated the notification.
 	ThreadID *int `json:"threadId,omitempty"`

--- a/pkg/report/v22/sarif/property_bag.go
+++ b/pkg/report/v22/sarif/property_bag.go
@@ -6,7 +6,7 @@ type PropertyBag struct {
 	Properties Properties `json:"properties,omitempty"`
 
 	// A set of distinct strings that provide additional information.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 }
 
 // NewPropertyBag - creates a new

--- a/pkg/report/v22/sarif/reporting_configuration.go
+++ b/pkg/report/v22/sarif/reporting_configuration.go
@@ -3,10 +3,10 @@ package sarif
 // ReportingConfiguration - Information about a rule or notification that can be configured at runtime.
 type ReportingConfiguration struct {
 	// Specifies whether the report may be produced during the scan.
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 
 	// Specifies the failure level for the report.
-	Level string `json:"level,omitempty"`
+	Level string `json:"level"`
 
 	// Contains configuration information specific to a report.
 	Parameters *PropertyBag `json:"parameters,omitempty"`

--- a/pkg/report/v22/sarif/reporting_descriptor.go
+++ b/pkg/report/v22/sarif/reporting_descriptor.go
@@ -39,7 +39,7 @@ type ReportingDescriptor struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of objects that describe relationships between this reporting descriptor and others.
-	Relationships []*ReportingDescriptorRelationship `json:"relationships,omitempty"`
+	Relationships []*ReportingDescriptorRelationship `json:"relationships"`
 
 	// A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text.
 	ShortDescription *MultiformatMessageString `json:"shortDescription,omitempty"`

--- a/pkg/report/v22/sarif/reporting_descriptor_relationship.go
+++ b/pkg/report/v22/sarif/reporting_descriptor_relationship.go
@@ -6,7 +6,7 @@ type ReportingDescriptorRelationship struct {
 	Description *Message `json:"description,omitempty"`
 
 	// A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.
-	Kinds []string `json:"kinds,omitempty"`
+	Kinds []string `json:"kinds"`
 
 	// Key/value pairs that provide additional information about the reporting descriptor reference.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/result.go
+++ b/pkg/report/v22/sarif/result.go
@@ -2,35 +2,35 @@ package sarif
 
 // Result - A result produced by an analysis tool.
 type Result struct {
-	// A set of strings that contribute to the stable, unique identity of the result.
-	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
-
 	// A set of strings each of which individually defines a stable, unique identity for the result.
 	Fingerprints map[string]string `json:"fingerprints,omitempty"`
+
+	// A set of strings that contribute to the stable, unique identity of the result.
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
 
 	// Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred.
 	AnalysisTarget *ArtifactLocation `json:"analysisTarget,omitempty"`
 
 	// A set of artifacts relevant to the result.
-	Attachments []*Attachment `json:"attachments,omitempty"`
+	Attachments []*Attachment `json:"attachments"`
 
 	// The state of a result relative to a baseline of a previous run.
 	BaselineState *string `json:"baselineState,omitempty"`
 
 	// An array of 'codeFlow' objects relevant to the result.
-	CodeFlows []*CodeFlow `json:"codeFlows,omitempty"`
+	CodeFlows []*CodeFlow `json:"codeFlows"`
 
 	// A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.
 	CorrelationGuID *string `json:"correlationGuid,omitempty"`
 
 	// An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.
-	Fixes []*Fix `json:"fixes,omitempty"`
+	Fixes []*Fix `json:"fixes"`
 
 	// An array of one or more unique 'graphTraversal' objects.
-	GraphTraversals []*GraphTraversal `json:"graphTraversals,omitempty"`
+	GraphTraversals []*GraphTraversal `json:"graphTraversals"`
 
 	// An array of zero or more unique graph objects associated with the result.
-	Graphs []*Graph `json:"graphs,omitempty"`
+	Graphs []*Graph `json:"graphs"`
 
 	// A stable, unique identifier for the result in the form of a GUID.
 	Guid *Guid `json:"guid,omitempty"`
@@ -39,13 +39,13 @@ type Result struct {
 	HostedViewerURI *string `json:"hostedViewerUri,omitempty"`
 
 	// A value that categorizes results by evaluation state.
-	Kind string `json:"kind,omitempty"`
+	Kind string `json:"kind"`
 
 	// A value specifying the severity level of the result.
-	Level string `json:"level,omitempty"`
+	Level string `json:"level"`
 
 	// The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.
-	Locations []*Location `json:"locations,omitempty"`
+	Locations []*Location `json:"locations"`
 
 	// A message that describes the result. The first sentence of the message only will be displayed when visible space is limited.
 	Message *Message `json:"message,omitempty"`
@@ -63,7 +63,7 @@ type Result struct {
 	Rank float64 `json:"rank"`
 
 	// A set of locations relevant to this result.
-	RelatedLocations []*Location `json:"relatedLocations,omitempty"`
+	RelatedLocations []*Location `json:"relatedLocations"`
 
 	// A reference used to locate the rule descriptor relevant to this result.
 	Rule *ReportingDescriptorReference `json:"rule,omitempty"`
@@ -75,13 +75,13 @@ type Result struct {
 	RuleIndex int `json:"ruleIndex"`
 
 	// An array of 'stack' objects relevant to the result.
-	Stacks []*Stack `json:"stacks,omitempty"`
+	Stacks []*Stack `json:"stacks"`
 
 	// A set of suppressions relevant to this result.
 	Suppressions []*Suppression `json:"suppressions,omitempty"`
 
 	// An array of references to taxonomy reporting descriptors that are applicable to the result.
-	Taxa []*ReportingDescriptorReference `json:"taxa,omitempty"`
+	Taxa []*ReportingDescriptorReference `json:"taxa"`
 
 	// A web request associated with this result.
 	WebRequest *WebRequest `json:"webRequest,omitempty"`
@@ -114,18 +114,6 @@ func NewResult() *Result {
 	}
 }
 
-// AddPartialFingerprint - add a single PartialFingerprint to the Result
-func (p *Result) AddPartialFingerprint(key, partialFingerprint string) *Result {
-	p.PartialFingerprints[key] = partialFingerprint
-	return p
-}
-
-// WithPartialFingerprints - add a PartialFingerprints to the Result
-func (p *Result) WithPartialFingerprints(partialFingerprints map[string]string) *Result {
-	p.PartialFingerprints = partialFingerprints
-	return p
-}
-
 // AddFingerprint - add a single Fingerprint to the Result
 func (f *Result) AddFingerprint(key, fingerprint string) *Result {
 	f.Fingerprints[key] = fingerprint
@@ -136,6 +124,18 @@ func (f *Result) AddFingerprint(key, fingerprint string) *Result {
 func (f *Result) WithFingerprints(fingerprints map[string]string) *Result {
 	f.Fingerprints = fingerprints
 	return f
+}
+
+// AddPartialFingerprint - add a single PartialFingerprint to the Result
+func (p *Result) AddPartialFingerprint(key, partialFingerprint string) *Result {
+	p.PartialFingerprints[key] = partialFingerprint
+	return p
+}
+
+// WithPartialFingerprints - add a PartialFingerprints to the Result
+func (p *Result) WithPartialFingerprints(partialFingerprints map[string]string) *Result {
+	p.PartialFingerprints = partialFingerprints
+	return p
 }
 
 // WithAnalysisTarget - add a AnalysisTarget to the Result

--- a/pkg/report/v22/sarif/result_provenance.go
+++ b/pkg/report/v22/sarif/result_provenance.go
@@ -3,7 +3,7 @@ package sarif
 // ResultProvenance - Contains information about how and when a result was detected.
 type ResultProvenance struct {
 	// An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.
-	ConversionSources []*PhysicalLocation `json:"conversionSources,omitempty"`
+	ConversionSources []*PhysicalLocation `json:"conversionSources"`
 
 	// A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.
 	FirstDetectionRunGuID *string `json:"firstDetectionRunGuid,omitempty"`

--- a/pkg/report/v22/sarif/run.go
+++ b/pkg/report/v22/sarif/run.go
@@ -6,7 +6,7 @@ type Run struct {
 	OriginalUriBaseIds map[string]ArtifactLocation `json:"originalUriBaseIds,omitempty"`
 
 	// Addresses associated with this run instance, if any.
-	Addresses []*Address `json:"addresses,omitempty"`
+	Addresses []*Address `json:"addresses"`
 
 	// An array of artifact objects relevant to the run.
 	Artifacts []*Artifact `json:"artifacts,omitempty"`
@@ -33,58 +33,58 @@ type Run struct {
 	ExternalPropertyFileReferences *ExternalPropertyFileReferences `json:"externalPropertyFileReferences,omitempty"`
 
 	// An array of zero or more unique graph objects associated with the run.
-	Graphs []*Graph `json:"graphs,omitempty"`
+	Graphs []*Graph `json:"graphs"`
 
 	// Describes the invocation of the analysis tool.
-	Invocations []*Invocation `json:"invocations,omitempty"`
+	Invocations []*Invocation `json:"invocations"`
 
 	// The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).
 	Language *Language `json:"language,omitempty"`
 
 	// An array of logical locations such as namespaces, types or functions.
-	LogicalLocations []*LogicalLocation `json:"logicalLocations,omitempty"`
+	LogicalLocations []*LogicalLocation `json:"logicalLocations"`
 
 	// An ordered list of character sequences that were treated as line breaks when computing region information for the run.
-	NewlineSequences []string `json:"newlineSequences,omitempty"`
+	NewlineSequences []string `json:"newlineSequences"`
 
 	// Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).
-	Policies []*ToolComponent `json:"policies,omitempty"`
+	Policies []*ToolComponent `json:"policies"`
 
 	// Key/value pairs that provide additional information about the run.
 	Properties *PropertyBag `json:"properties,omitempty"`
 
 	// An array of strings used to replace sensitive information in a redaction-aware property.
-	RedactionTokens []string `json:"redactionTokens,omitempty"`
+	RedactionTokens []string `json:"redactionTokens"`
 
 	// The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.
-	Results []*Result `json:"results,omitempty"`
+	Results []*Result `json:"results"`
 
 	// Automation details that describe the aggregate of runs to which this run belongs.
-	RunAggregates []*RunAutomationDetails `json:"runAggregates,omitempty"`
+	RunAggregates []*RunAutomationDetails `json:"runAggregates"`
 
 	// A specialLocations object that defines locations of special significance to SARIF consumers.
 	SpecialLocations *SpecialLocations `json:"specialLocations,omitempty"`
 
 	// An array of toolComponent objects relevant to a taxonomy in which results are categorized.
-	Taxonomies []*ToolComponent `json:"taxonomies,omitempty"`
+	Taxonomies []*ToolComponent `json:"taxonomies"`
 
 	// An array of threadFlowLocation objects cached at run level.
-	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations,omitempty"`
+	ThreadFlowLocations []*ThreadFlowLocation `json:"threadFlowLocations"`
 
 	// Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.
 	Tool *Tool `json:"tool,omitempty"`
 
 	// The set of available translations of the localized data provided by the tool.
-	Translations []*ToolComponent `json:"translations,omitempty"`
+	Translations []*ToolComponent `json:"translations"`
 
 	// Specifies the revision in version control of the artifacts that were scanned.
-	VersionControlProvenance []*VersionControlDetails `json:"versionControlProvenance,omitempty"`
+	VersionControlProvenance []*VersionControlDetails `json:"versionControlProvenance"`
 
 	// An array of request objects cached at run level.
-	WebRequests []*WebRequest `json:"webRequests,omitempty"`
+	WebRequests []*WebRequest `json:"webRequests"`
 
 	// An array of response objects cached at run level.
-	WebResponses []*WebResponse `json:"webResponses,omitempty"`
+	WebResponses []*WebResponse `json:"webResponses"`
 }
 
 // NewRun - creates a new

--- a/pkg/report/v22/sarif/stack_frame.go
+++ b/pkg/report/v22/sarif/stack_frame.go
@@ -9,7 +9,7 @@ type StackFrame struct {
 	Module *string `json:"module,omitempty"`
 
 	// The parameters of the call that is executing.
-	Parameters []string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters"`
 
 	// Key/value pairs that provide additional information about the stack frame.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/thread_flow_location.go
+++ b/pkg/report/v22/sarif/thread_flow_location.go
@@ -12,13 +12,13 @@ type ThreadFlowLocation struct {
 	ExecutionTimeUtc *string `json:"executionTimeUtc,omitempty"`
 
 	// Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is "essential", "important", "unimportant". Default: "important".
-	Importance string `json:"importance,omitempty"`
+	Importance string `json:"importance"`
 
 	// The index within the run threadFlowLocations array.
 	Index int `json:"index"`
 
 	// A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.
-	Kinds []string `json:"kinds,omitempty"`
+	Kinds []string `json:"kinds"`
 
 	// The code location.
 	Location *Location `json:"location,omitempty"`
@@ -36,7 +36,7 @@ type ThreadFlowLocation struct {
 	Stack *Stack `json:"stack,omitempty"`
 
 	// An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.
-	Taxa []*ReportingDescriptorReference `json:"taxa,omitempty"`
+	Taxa []*ReportingDescriptorReference `json:"taxa"`
 
 	// A web request associated with this thread flow location.
 	WebRequest *WebRequest `json:"webRequest,omitempty"`

--- a/pkg/report/v22/sarif/tool.go
+++ b/pkg/report/v22/sarif/tool.go
@@ -6,7 +6,7 @@ type Tool struct {
 	Driver *ToolComponent `json:"driver,omitempty"`
 
 	// Tool extensions that contributed to or reconfigured the analysis tool that was run.
-	Extensions []*ToolComponent `json:"extensions,omitempty"`
+	Extensions []*ToolComponent `json:"extensions"`
 
 	// Key/value pairs that provide additional information about the tool.
 	Properties *PropertyBag `json:"properties,omitempty"`

--- a/pkg/report/v22/sarif/tool_component.go
+++ b/pkg/report/v22/sarif/tool_component.go
@@ -9,7 +9,7 @@ type ToolComponent struct {
 	AssociatedComponent *ToolComponentReference `json:"associatedComponent,omitempty"`
 
 	// The kinds of data contained in this object.
-	Contents []string `json:"contents,omitempty"`
+	Contents []string `json:"contents"`
 
 	// The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).
 	DottedQuadFileVersion *string `json:"dottedQuadFileVersion,omitempty"`
@@ -30,7 +30,7 @@ type ToolComponent struct {
 	InformationURI *string `json:"informationUri,omitempty"`
 
 	// Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.
-	IsComprehensive bool `json:"isComprehensive,omitempty"`
+	IsComprehensive bool `json:"isComprehensive"`
 
 	// The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).
 	Language *Language `json:"language,omitempty"`
@@ -39,7 +39,7 @@ type ToolComponent struct {
 	LocalizedDataSemanticVersion *string `json:"localizedDataSemanticVersion,omitempty"`
 
 	// An array of the artifactLocation objects associated with the tool component.
-	Locations []*ArtifactLocation `json:"locations,omitempty"`
+	Locations []*ArtifactLocation `json:"locations"`
 
 	// The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.
 	MinimumRequiredLocalizedDataSemanticVersion *string `json:"minimumRequiredLocalizedDataSemanticVersion,omitempty"`
@@ -48,7 +48,7 @@ type ToolComponent struct {
 	Name *string `json:"name,omitempty"`
 
 	// An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.
-	Notifications []*ReportingDescriptor `json:"notifications,omitempty"`
+	Notifications []*ReportingDescriptor `json:"notifications"`
 
 	// The organization or company that produced the tool component.
 	Organization *string `json:"organization,omitempty"`
@@ -66,7 +66,7 @@ type ToolComponent struct {
 	ReleaseDateUtc *string `json:"releaseDateUtc,omitempty"`
 
 	// An array of reportingDescriptor objects relevant to the analysis performed by the tool component.
-	Rules []*ReportingDescriptor `json:"rules,omitempty"`
+	Rules []*ReportingDescriptor `json:"rules"`
 
 	// The tool component version in the format specified by Semantic Versioning 2.0.
 	SemanticVersion *string `json:"semanticVersion,omitempty"`
@@ -75,10 +75,10 @@ type ToolComponent struct {
 	ShortDescription *MultiformatMessageString `json:"shortDescription,omitempty"`
 
 	// An array of toolComponentReference objects to declare the taxonomies supported by the tool component.
-	SupportedTaxonomies []*ToolComponentReference `json:"supportedTaxonomies,omitempty"`
+	SupportedTaxonomies []*ToolComponentReference `json:"supportedTaxonomies"`
 
 	// An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.
-	Taxa []*ReportingDescriptor `json:"taxa,omitempty"`
+	Taxa []*ReportingDescriptor `json:"taxa"`
 
 	// Translation metadata, required for a translation, not populated by other component types.
 	TranslationMetadata *TranslationMetadata `json:"translationMetadata,omitempty"`

--- a/pkg/report/v22/sarif/web_request.go
+++ b/pkg/report/v22/sarif/web_request.go
@@ -2,11 +2,11 @@ package sarif
 
 // WebRequest - Describes an HTTP request.
 type WebRequest struct {
-	// The request parameters.
-	Parameters map[string]string `json:"parameters,omitempty"`
-
 	// The request headers.
 	Headers map[string]string `json:"headers,omitempty"`
+
+	// The request parameters.
+	Parameters map[string]string `json:"parameters,omitempty"`
 
 	// The body of the request.
 	Body *ArtifactContent `json:"body,omitempty"`
@@ -37,18 +37,6 @@ func NewWebRequest() *WebRequest {
 	}
 }
 
-// AddParameter - add a single Parameter to the WebRequest
-func (p *WebRequest) AddParameter(key, parameter string) *WebRequest {
-	p.Parameters[key] = parameter
-	return p
-}
-
-// WithParameters - add a Parameters to the WebRequest
-func (p *WebRequest) WithParameters(parameters map[string]string) *WebRequest {
-	p.Parameters = parameters
-	return p
-}
-
 // AddHeader - add a single Header to the WebRequest
 func (h *WebRequest) AddHeader(key, header string) *WebRequest {
 	h.Headers[key] = header
@@ -59,6 +47,18 @@ func (h *WebRequest) AddHeader(key, header string) *WebRequest {
 func (h *WebRequest) WithHeaders(headers map[string]string) *WebRequest {
 	h.Headers = headers
 	return h
+}
+
+// AddParameter - add a single Parameter to the WebRequest
+func (p *WebRequest) AddParameter(key, parameter string) *WebRequest {
+	p.Parameters[key] = parameter
+	return p
+}
+
+// WithParameters - add a Parameters to the WebRequest
+func (p *WebRequest) WithParameters(parameters map[string]string) *WebRequest {
+	p.Parameters = parameters
+	return p
 }
 
 // WithBody - add a Body to the WebRequest

--- a/pkg/report/v22/sarif/web_response.go
+++ b/pkg/report/v22/sarif/web_response.go
@@ -12,7 +12,7 @@ type WebResponse struct {
 	Index int `json:"index"`
 
 	// Specifies whether a response was received from the server.
-	NoResponseReceived bool `json:"noResponseReceived,omitempty"`
+	NoResponseReceived bool `json:"noResponseReceived"`
 
 	// Key/value pairs that provide additional information about the response.
 	Properties *PropertyBag `json:"properties,omitempty"`


### PR DESCRIPTION
Where items have default values then don't use omitempty.
Special case for GitHub where Run.Results is expected even if its empty.

This is a deviation from the spec but I guess GitHub
