### PR TITLE
Fix: Don't omit 'run' if empty and fix omitted 'kind' and 'level' attributes in result

### DIFF
--- a/pkg/report/v210/sarif/result.go
+++ b/pkg/report/v210/sarif/result.go
@@ -39,10 +39,10 @@ type Result struct {
 	HostedViewerURI *string `json:"hostedViewerUri,omitempty"`
 
 	// A value that categorizes results by evaluation state.
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// A value specifying the severity level of the result.
-	Level string `json:"level"`
+	Level string `json:"level,omitempty"`
 
 	// The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.
 	Locations []*Location `json:"locations"`

--- a/pkg/report/v210/sarif/sarif.go
+++ b/pkg/report/v210/sarif/sarif.go
@@ -18,7 +18,7 @@ type Report struct {
 	Version string `json:"version"`
 
 	// The set of runs contained in this log file.
-	Runs []*Run `json:"runs,omitempty"`
+	Runs []*Run `json:"runs"`
 
 	// References to external property files that should be inlined with the content of a root log file.
 	InlineExternalProperties []*ExternalProperties `json:"inlineExternalProperties,omitempty"`


### PR DESCRIPTION

Following:
* https://github.com/owenrumney/go-sarif/pull/104

Causing a lot of issues, if we are trying to unmarshal a report generated not by this tool or library (for example component written in other languages). making changes and then marshaling it.

---

## We should not omit empty `Runs`:
if you try to upload to Github
```
Run github/codeql-action/upload-sarif@v3
Uploading code scanning results
Error details: instance requires property "runs"
Error: Unable to upload "jfrog_sast.sarif" as it is not valid SARIF:
- instance requires property "runs"
```
also mentioned in spec that is required: 
* https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790732


## 'level' and 'kind' attributes can be calculated if omitted based on the spec:
* https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790897
* https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790898

If we are loading a report with those missing attributes and marshal again, we are not even getting the default values and only "" (since not omitted).
```
Error details: instance.runs[1].results[3].kind is not one of enum values: notApplicable,pass,fail,review,open,informational
Error details: instance.runs[1].results[3].level is not one of enum values: none,note,warning,error
```
I'm suggesting those values should be omitted. `Github` can also proccess them if omitted.