### PR TITLE
Omit empty level in ReportingConfiguration

### DIFF
--- a/pkg/report/v210/sarif/reporting_configuration.go
+++ b/pkg/report/v210/sarif/reporting_configuration.go
@@ -6,7 +6,7 @@ type ReportingConfiguration struct {
 	Enabled bool `json:"enabled"`
 
 	// Specifies the failure level for the report.
-	Level string `json:"level"`
+	Level string `json:"level,omitempty"`
 
 	// Contains configuration information specific to a report.
 	Parameters *PropertyBag `json:"parameters,omitempty"`


### PR DESCRIPTION
Following the issue raised in:
* https://github.com/owenrumney/go-sarif/pull/106

Similar issue, the `level` attribute in rule configuration is optional and affects the calculation of the results level.
It should be omitted when not provided.
https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141791105