### PR TITLE
fix: Ensure that empty arrays are initialised

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,62 +105,65 @@ This example is taken directly from the [Microsoft SARIF pages](https://github.c
 
 ```json
 {
-  "version": "2.1.0",
-  "$schema": "(https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json)",
-  "runs": [
-    {
-      "tool": {
-        "driver": {
-          "name": "ESLint",
-          "informationUri": "https://eslint.org",
-          "rules": [
-            {
-              "id": "no-unused-vars",
-              "shortDescription": {
-                "text": "disallow unused variables"
-              },
-              "helpUri": "https://eslint.org/docs/rules/no-unused-vars",
-              "properties": {
-                "category": "Variables"
-              }
-            }
-          ]
-        }
-      },
-      "artifacts": [
-        {
-          "location": {
-            "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js"
-          }
-        }
-      ],
-      "results": [
-        {
-          "level": "error",
-          "message": {
-            "text": "'x' is assigned a value but never used."
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js",
-                  "index": 0
+    "version": "2.1.0",
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "runs": [
+      {
+        "tool": {
+          "driver": {
+            "name": "ESLint",
+            "informationUri": "https://eslint.org",
+            "language": "en-US",
+            "rules": [
+              {
+                "id": "no-unused-vars",
+                "shortDescription": {
+                  "text": "disallow unused variables"
                 },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 5
+                "helpUri": "https://eslint.org/docs/rules/no-unused-vars",
+                "properties": {
+                  "category": "Variables"
                 }
               }
+            ]
+          }
+        },
+        "language": "en-US",
+        "newlineSequences": ["\r\n", "\n"],
+        "artifacts": [
+          {
+            "location": {
+              "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js"
             }
-          ],
-          "ruleId": "no-unused-vars",
-          "ruleIndex": 0
-        }
-      ]
-    }
-  ]
-}
+          }
+        ],
+        "results": [
+          {
+            "level": "error",
+            "message": {
+              "text": "'x' is assigned a value but never used."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js",
+                    "index": 0
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "startColumn": 5
+                  }
+                }
+              }
+            ],
+            "ruleId": "no-unused-vars",
+            "ruleIndex": 0
+          }
+        ]
+      }
+    ]
+  }
 ```
 
 

--- a/pkg/report/v210/sarif/sarif_companion.go
+++ b/pkg/report/v210/sarif/sarif_companion.go
@@ -1,0 +1,75 @@
+package sarif
+
+import (
+	"reflect"
+	"strings"
+)
+
+func initializeArrays(v interface{}) {
+	initializeArraysValue(reflect.ValueOf(v))
+}
+
+func initializeArraysValue(val reflect.Value) {
+	initializeArraysValueWithParent(val, reflect.StructField{})
+}
+
+func initializeArraysValueWithParent(val reflect.Value, structField reflect.StructField) {
+	if !val.IsValid() {
+		return
+	}
+
+	switch val.Kind() {
+	case reflect.Ptr:
+		if val.IsNil() {
+			return
+		}
+		initializeArraysValueWithParent(val.Elem(), structField)
+
+	case reflect.Interface:
+		if val.IsNil() {
+			return
+		}
+		initializeArraysValueWithParent(val.Elem(), structField)
+
+	case reflect.Slice:
+		if val.IsNil() && val.CanSet() {
+			if !hasOmitEmpty(structField) {
+				val.Set(reflect.MakeSlice(val.Type(), 0, 0))
+			}
+		}
+		for i := 0; i < val.Len(); i++ {
+			initializeArraysValueWithParent(val.Index(i), reflect.StructField{})
+		}
+
+	case reflect.Struct:
+		structType := val.Type()
+		for i := 0; i < val.NumField(); i++ {
+			field := val.Field(i)
+			fieldType := structType.Field(i)
+			if field.CanSet() || field.CanInterface() {
+				initializeArraysValueWithParent(field, fieldType)
+			}
+		}
+
+	case reflect.Map:
+		if val.IsNil() {
+			return
+		}
+		for _, key := range val.MapKeys() {
+			initializeArraysValueWithParent(val.MapIndex(key), reflect.StructField{})
+		}
+	}
+}
+
+func hasOmitEmpty(field reflect.StructField) bool {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return false
+	}
+	for i, part := range strings.Split(tag, ",") {
+		if i > 0 && part == "omitempty" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/report/v22/sarif/sarif.go
+++ b/pkg/report/v22/sarif/sarif.go
@@ -30,6 +30,18 @@ type Report struct {
 	Properties *PropertyBag `json:"properties,omitempty"`
 }
 
+type OpenOption func(*openConfig)
+
+type openConfig struct {
+	strict bool
+}
+
+func WithStrictValidation() OpenOption {
+	return func(cfg *openConfig) {
+		cfg.strict = true
+	}
+}
+
 func NewReport() *Report {
 	return &Report{
 		Version:                  "2.2",
@@ -79,7 +91,7 @@ func NewRunWithInformationURI(toolName, informationURI string) *Run {
 }
 
 // Open loads a Report from a file
-func Open(filename string) (*Report, error) {
+func Open(filename string, options ...OpenOption) (*Report, error) {
 	if _, err := os.Stat(filename); err != nil && os.IsNotExist(err) {
 		return nil, errors.New("the provided file path doesn't have a file")
 	}
@@ -88,19 +100,28 @@ func Open(filename string) (*Report, error) {
 	if err != nil {
 		return nil, fmt.Errorf("the provided filepath could not be opened. %w", err)
 	}
-	return FromBytes(content)
+	return FromBytes(content, options...)
 }
 
 // FromString loads a Report from string content
-func FromString(content string) (*Report, error) {
-	return FromBytes([]byte(content))
+func FromString(content string, options ...OpenOption) (*Report, error) {
+	return FromBytes([]byte(content), options...)
 }
 
 // FromBytes loads a Report from a byte array
-func FromBytes(content []byte) (*Report, error) {
+func FromBytes(content []byte, options ...OpenOption) (*Report, error) {
 	var report Report
 	if err := json.Unmarshal(content, &report); err != nil {
 		return nil, err
+	}
+
+	cfg := &openConfig{}
+	for _, opt := range options {
+		opt(cfg)
+	}
+
+	if !cfg.strict {
+		initializeArrays(&report)
 	}
 	return &report, nil
 }

--- a/pkg/report/v22/sarif/sarif_companion.go
+++ b/pkg/report/v22/sarif/sarif_companion.go
@@ -1,0 +1,75 @@
+package sarif
+
+import (
+	"reflect"
+	"strings"
+)
+
+func initializeArrays(v interface{}) {
+	initializeArraysValue(reflect.ValueOf(v))
+}
+
+func initializeArraysValue(val reflect.Value) {
+	initializeArraysValueWithParent(val, reflect.StructField{})
+}
+
+func initializeArraysValueWithParent(val reflect.Value, structField reflect.StructField) {
+	if !val.IsValid() {
+		return
+	}
+
+	switch val.Kind() {
+	case reflect.Ptr:
+		if val.IsNil() {
+			return
+		}
+		initializeArraysValueWithParent(val.Elem(), structField)
+
+	case reflect.Interface:
+		if val.IsNil() {
+			return
+		}
+		initializeArraysValueWithParent(val.Elem(), structField)
+
+	case reflect.Slice:
+		if val.IsNil() && val.CanSet() {
+			if !hasOmitEmpty(structField) {
+				val.Set(reflect.MakeSlice(val.Type(), 0, 0))
+			}
+		}
+		for i := 0; i < val.Len(); i++ {
+			initializeArraysValueWithParent(val.Index(i), reflect.StructField{})
+		}
+
+	case reflect.Struct:
+		structType := val.Type()
+		for i := 0; i < val.NumField(); i++ {
+			field := val.Field(i)
+			fieldType := structType.Field(i)
+			if field.CanSet() || field.CanInterface() {
+				initializeArraysValueWithParent(field, fieldType)
+			}
+		}
+
+	case reflect.Map:
+		if val.IsNil() {
+			return
+		}
+		for _, key := range val.MapKeys() {
+			initializeArraysValueWithParent(val.MapIndex(key), reflect.StructField{})
+		}
+	}
+}
+
+func hasOmitEmpty(field reflect.StructField) bool {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return false
+	}
+	for i, part := range strings.Split(tag, ",") {
+		if i > 0 && part == "omitempty" {
+			return true
+		}
+	}
+	return false
+}

--- a/test/v210/report_stage_test.go
+++ b/test/v210/report_stage_test.go
@@ -90,11 +90,19 @@ func (r *reportTest) the_report_has_expected_driver_name_and_information_uri(dri
 	assert.Equal(r.t, informationURI, *r.report.Runs[0].Tool.Driver.InformationURI)
 }
 
-func (r *reportTest) a_report_is_loaded_from_a_file(filename string) {
-	report, err := sarif.Open(filename)
+func (r *reportTest) a_report_is_loaded_from_a_file(filename string, options ...sarif.OpenOption) {
+	report, err := sarif.Open(filename, options...)
 	if err != nil {
 		panic(err)
 	}
 	r.report = report
 
+}
+
+func (r *reportTest) the_report_is_valid() {
+	require.NoError(r.t, r.report.Validate())
+}
+
+func (r *reportTest) the_report_is_invalid() {
+	require.Error(r.t, r.report.Validate())
 }

--- a/test/v210/report_test.go
+++ b/test/v210/report_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -121,4 +122,25 @@ func Test_err_on_load_sarif_report_from_file_when_file_not_legit(t *testing.T) {
 		}
 	}()
 	given.a_report_is_loaded_from_a_file("/tmp")
+}
+
+func Test_validate_report(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	given.a_report_is_loaded_from_a_file("testdata/new_simple_report_with_single_run.json")
+	then.the_report_is_valid()
+}
+
+func Test_validate_with_strict_validation_report(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	given.a_report_is_loaded_from_a_file("testdata/new_simple_report_with_single_run_with_errors.json", sarif.WithStrictValidation())
+	then.the_report_is_invalid()
+}
+
+func Test_validate_report_with_strict_validation_disabled(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	given.a_report_is_loaded_from_a_file("testdata/new_simple_report_with_single_run_with_errors.json")
+	then.the_report_is_valid()
 }

--- a/test/v210/testdata/new_simple_report_with_single_run_with_errors.json
+++ b/test/v210/testdata/new_simple_report_with_single_run_with_errors.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "language": "en-US",
+      "logicalLocations": [],
+      "newlineSequences": ["\r\n", "\n"],
+      "policies": [],
+      "redactionTokens": [],
+      "results": [],
+      "runAggregates": [],
+      "taxonomies": [],
+      "threadFlowLocations": [],
+      "tool": {
+        "driver": {
+          "language": "en-US",
+          "informationUri": "https://tfsec.dev",
+          "isComprehensive": false,
+          "locations": [],
+          "name": "tfsec",
+          "notifications": [],
+          "rules": [],
+          "supportedTaxonomies": [],
+          "taxa": []
+        },
+        "extensions": []
+      },
+      "translations": [],
+      "versionControlProvenance": [],
+      "webRequests": [],
+      "webResponses": []
+    }
+  ],
+  "properties": {}
+}

--- a/test/v22/report_stage_test.go
+++ b/test/v22/report_stage_test.go
@@ -91,11 +91,18 @@ func (r *reportTest) the_report_has_expected_driver_name_and_information_uri(dri
 	assert.Equal(r.t, informationURI, *r.report.Runs[0].Tool.Driver.InformationURI)
 }
 
-func (r *reportTest) a_report_is_loaded_from_a_file(filename string) {
-	report, err := sarif.Open(filename)
+func (r *reportTest) a_report_is_loaded_from_a_file(filename string, options ...sarif.OpenOption) {
+	report, err := sarif.Open(filename, options...)
 	if err != nil {
 		panic(err)
 	}
 	r.report = report
+}
 
+func (r *reportTest) the_report_is_valid() {
+	require.NoError(r.t, r.report.Validate())
+}
+
+func (r *reportTest) the_report_is_invalid() {
+	require.Error(r.t, r.report.Validate())
 }

--- a/test/v22/report_test.go
+++ b/test/v22/report_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/owenrumney/go-sarif/v3/pkg/report/v22/sarif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -121,4 +122,25 @@ func Test_err_on_load_sarif_report_from_file_when_file_not_legit(t *testing.T) {
 		}
 	}()
 	given.a_report_is_loaded_from_a_file("/tmp")
+}
+
+func Test_validate_report(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	given.a_report_is_loaded_from_a_file("testdata/new_simple_report_with_single_run.json")
+	then.the_report_is_valid()
+}
+
+func Test_validate_with_strict_validation_report(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	given.a_report_is_loaded_from_a_file("testdata/new_simple_report_with_single_run_with_errors.json", sarif.WithStrictValidation())
+	then.the_report_is_invalid()
+}
+
+func Test_validate_report_with_strict_validation_disabled(t *testing.T) {
+	given, _, then := newReportTest(t)
+
+	given.a_report_is_loaded_from_a_file("testdata/new_simple_report_with_single_run_with_errors.json")
+	then.the_report_is_valid()
 }

--- a/test/v22/testdata/new_simple_report_with_single_run_with_errors.json
+++ b/test/v22/testdata/new_simple_report_with_single_run_with_errors.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.2/schema/sarif-2-2.schema.json",
+  "version": "2.2",
+  "runs": [
+    {
+      "newlineSequences": ["\r\n", "\n"],
+      "tool": {
+        "driver": {
+          "informationUri": "https://tfsec.dev",
+          "name": "tfsec"
+        }
+      }
+    }
+  ],
+  "guid": "516d8cc4-18b1-463e-9e0e-417473149927"
+}


### PR DESCRIPTION
When loading a report from content we need to ensure that arrays that would normally be initialised have been done so or the validation won't work.

- add reflection during the load phase that will ensure the required properties are initialised as required
  - slices with the `omitempty` tag will not be initialised, this should ensure the output is the same as the input.
- add tests to verify


Closes #112 